### PR TITLE
Initiate connections to room peers on join

### DIFF
--- a/network/tunnel_connect.go
+++ b/network/tunnel_connect.go
@@ -33,6 +33,7 @@ func (n *Node) TunnelPlugin() ssb.Plugin {
 	return plugin{
 		h: handleNewConnection{
 			Handler: &rootHdlr,
+			network: n,
 			logger:  tunnelLogger,
 		},
 	}
@@ -104,6 +105,7 @@ func (h connectHandler) HandleDuplex(ctx context.Context, req *muxrpc.Request, p
 // handleNewConnection wrapps a muxrpc.Handler to do some stuff with new connections
 type handleNewConnection struct {
 	muxrpc.Handler
+	network *Node
 
 	logger kitlog.Logger
 }
@@ -158,6 +160,7 @@ func (newConn handleNewConnection) HandleConnect(ctx context.Context, edp muxrpc
 	}
 	for i, f := range initState.IDs {
 		level.Info(peerLogger).Log("i", i, "attendant", f.String())
+		newConn.network.DialViaRoom(remote, f)
 	}
 
 	// stream further updates


### PR DESCRIPTION
Part of https://github.com/planetary-social/planetary-ios/issues/722.

This takes the extremely naive approach of initiating a connection to every peer in a room server when it is joined. I was able to get two copies of Planetary iOS replicating through the room this way. 

I'm not sure if this is architecturally the right way to do things, but it's a start so if possible I'd like to get this merged in for MVP room support. Future improvements could be only initiating connections to peers within 1 or 2 hops, and initiating connections when new peers join the room, not just when you join.