### PR TITLE
Always recurse to process followees of people we follow

### DIFF
--- a/graph/builder.go
+++ b/graph/builder.go
@@ -450,19 +450,9 @@ func (b *BadgerBuilder) recurseHops(walked *ssb.StrFeedSet, vis map[string]struc
 			return err
 		}
 
-		// TODO: use from follows followedByWho
-		dstFollows, err := b.Follows(followedByWho)
-		if err != nil {
-			return fmt.Errorf("recurseHops(%d): follows from entry(%d) failed: %w", depth, i, err)
+		if err := b.recurseHops(walked, vis, followedByWho, depth-1); err != nil {
+			return err
 		}
-
-		isF := dstFollows.Has(who)
-		if isF { // found a friend, recurse
-			if err := b.recurseHops(walked, vis, followedByWho, depth-1); err != nil {
-				return err
-			}
-		}
-		// b.log.Log("depth", depth, "from", from.ShortRef(), "follows", followedByWho.ShortRef(), "friend", isF, "cnt", dstFollows.Count())
 	}
 
 	// mark them as visited


### PR DESCRIPTION
Under normal circumstances SSB clients build a list of feeds which should be replicated by analysing contact messages. Each contact messages creates a directed edge connecting two vertices constituting relevant feeds in the so-called social graph. To create a list of feeds to replicate the graph is walked following the directed edges up to a certain depth, starting with the local node.

This behaviour is more complicated in go-ssb. The library will only follow the edge if the edge is mutual (sometimes referred to as "friends"). This was reported as counterintuitive as other clients do not behave in this way.

This commit changes this behaviour to the default behaviour described in the first paragraph of this commit message.