### PR TITLE
Fix ebt downloading own feed

### DIFF
--- a/plugins/ebt/handler.go
+++ b/plugins/ebt/handler.go
@@ -115,7 +115,7 @@ func (h *MUXRPCHandler) sendState(ctx context.Context, tx *muxrpc.ByteSink, remo
 	selfRef := h.self.String()
 
 	// don't receive your own feed
-	if myNote, has := currState[selfRef]; has && myNote.Seq > 0 {
+	if myNote, has := currState[selfRef]; has {
 		myNote.Receive = false
 		currState[selfRef] = myNote
 	}

--- a/plugins/ebt/handler.go
+++ b/plugins/ebt/handler.go
@@ -115,7 +115,7 @@ func (h *MUXRPCHandler) sendState(ctx context.Context, tx *muxrpc.ByteSink, remo
 	selfRef := h.self.String()
 
 	// don't receive your own feed
-	if myNote, has := currState[selfRef]; has {
+	if myNote, has := currState[selfRef]; has && myNote.Seq > 0 {
 		myNote.Receive = false
 		currState[selfRef] = myNote
 	}

--- a/sbot/replicate_negotiation.go
+++ b/sbot/replicate_negotiation.go
@@ -58,15 +58,14 @@ func (rn replicateNegotiator) HandleConnect(ctx context.Context, e muxrpc.Endpoi
 
 	// initiate ebt channel
 	rx, tx, err := e.Duplex(ctx, muxrpc.TypeJSON, muxrpc.Method{"ebt", "replicate"}, opt)
+
+	err = rn.ebt.Loop(ctx, tx, rx, remoteAddr)
 	if err != nil {
 		level.Debug(rn.logger).Log("event", "no ebt support", "err", err)
-
 		// fallback to legacy
 		rn.lg.StartLegacyFetching(ctx, e)
 		return
 	}
-
-	rn.ebt.Loop(ctx, tx, rx, remoteAddr)
 }
 
 func (replicateNegotiator) Handled(m muxrpc.Method) bool { return false }


### PR DESCRIPTION
This fixes [#875](https://github.com/planetary-social/planetary-ios/issues/875). I discovered this while working on [#847](https://github.com/planetary-social/planetary-ios/issues/847), and I needed it fixed to do my temporary fix (disabling EBT on our pubs). The problem in the code was that the failure of ebt.replicate was not being bubbled up to replication_negotiaton.go. 